### PR TITLE
Bug fix for "Write-Warning" error when resource no longer exists in a…

### DIFF
--- a/azuremonitoring.ps1
+++ b/azuremonitoring.ps1
@@ -87,7 +87,7 @@ foreach ($rule in $alertRules) {
     }
     catch {
         # If the resource does not exist, delete the alert rule
-        Write-Warning "Resource $resourceId does not exist. Deleting alert rule $($rule.Name)..." -ForegroundColor Red -BackgroundColor Black
+        Write-Warning "Resource $resourceId does not exist. Deleting alert rule $($rule.Name)..."
         Remove-AzMetricAlertRuleV2 -ResourceGroupName $rule.resourceGroup -Name $rule.Name
         Write-Output "Alert rule $($rule.Name) deleted successfully." -ForegroundColor Yellow -BackgroundColor Black
     }


### PR DESCRIPTION
Bug fix for error resulting from a "Write-Warning" cmdlet that includes parameter flags that the cmdlet does not support. This section of the script is only reached when a resource type specified in an alert csv for monitoring no longer exists in azure and begins the process of deleting the alert rule which will follow the "Write-Warning" call. The fix removes these parameter flags for this call.